### PR TITLE
Flush logger on application shut-down

### DIFF
--- a/src/DDDBrisbane2016.Web/Global.asax.cs
+++ b/src/DDDBrisbane2016.Web/Global.asax.cs
@@ -67,6 +67,8 @@ namespace DDDBrisbane2016.Web
 
             _container?.Dispose();
             _container = null;
+
+            Log.CloseAndFlush();
         }
 
         protected void Application_Error()


### PR DESCRIPTION
It's possible queued log messages won't be transmitted when the app shuts down unless `Log.CloseAndFlush()` is called (or the `Logger` is disposed).

Added `CloseAndFlush()` call.